### PR TITLE
MongoDB. GridFS.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.hibernate.orm:hibernate-jcache:6.4.1.Final'
 	implementation 'org.ehcache:ehcache:3.10.8'
 	implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/chous/bookshelf/config/MongoConfig.java
+++ b/src/main/java/com/chous/bookshelf/config/MongoConfig.java
@@ -1,0 +1,41 @@
+package com.chous.bookshelf.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.gridfs.GridFsTemplate;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@EnableMongoRepositories(basePackages = "com.chous.bookshelf")
+public class MongoConfig extends AbstractMongoClientConfiguration {
+    private final MappingMongoConverter mappingMongoConverter;
+
+    @Value("${spring.data.mongodb.database}")
+    private String database;
+
+    // После создания класса MongoConfig возникает следующая ошибка:
+    // "Relying upon circular references is discouraged and they are prohibited by default.
+    // Update your application to remove the dependency cycle between beans. As a last resort,
+    // it may be possible to break the cycle automatically by setting spring.main.allow-circular-references to true."
+    // Я решила её добавлением аннотации @Lazy.
+    @Lazy
+    @Autowired
+    public MongoConfig(MappingMongoConverter mappingMongoConverter) {
+        this.mappingMongoConverter = mappingMongoConverter;
+    }
+
+    @Override
+    protected String getDatabaseName() {
+        return database;
+    }
+
+    @Bean
+    public GridFsTemplate gridFsTemplate() {
+        return new GridFsTemplate(mongoDbFactory(), mappingMongoConverter);
+    }
+}

--- a/src/main/java/com/chous/bookshelf/controller/ImageController.java
+++ b/src/main/java/com/chous/bookshelf/controller/ImageController.java
@@ -1,0 +1,69 @@
+package com.chous.bookshelf.controller;
+
+import com.chous.bookshelf.service.ImageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.data.mongodb.gridfs.GridFsResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@RestController
+@RequestMapping("/api/v1/books")
+public class ImageController {
+
+    String imageId;
+
+    private final ImageService imageService;
+
+    @Autowired
+    public ImageController(ImageService imageService) {
+        this.imageService = imageService;
+    }
+
+    @PostMapping("/{id}/upload-image")
+    public ResponseEntity<String> uploadImage(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
+
+        try {
+            imageId = imageService.uploadImage(file, id);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return ResponseEntity.ok("Image uploaded successfully");
+    }
+
+    @GetMapping("/{id}/download-image")
+    public ResponseEntity<InputStreamResource> downloadImage(@PathVariable Long id) {
+
+        try {
+            GridFsResource gridFsResource = imageService.getImageByBookId(id);
+
+            if (gridFsResource == null) {
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            }
+
+            InputStreamResource inputStreamResource = new InputStreamResource(gridFsResource.getInputStream());
+
+            HttpHeaders headers = new HttpHeaders();
+            String contentDisposition = "attachment; filename*=\"UTF-8''"+ gridFsResource.getFilename() + "\"";
+            headers.add(HttpHeaders.CONTENT_DISPOSITION, URLEncoder.encode(contentDisposition, StandardCharsets.UTF_8));
+
+            return ResponseEntity.ok()
+                    .headers(headers)
+                    .contentType(MediaType.parseMediaType(gridFsResource.getContentType()))
+                    .body(inputStreamResource);
+
+        } catch (Exception e) {
+            throw new RuntimeException("Error downloading image", e);
+        }
+    }
+
+}

--- a/src/main/java/com/chous/bookshelf/entity/Image.java
+++ b/src/main/java/com/chous/bookshelf/entity/Image.java
@@ -1,0 +1,13 @@
+package com.chous.bookshelf.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+public class Image {
+    @Id
+    private String id;
+
+    public Image() {
+    }
+}

--- a/src/main/java/com/chous/bookshelf/repository/ImageRepository.java
+++ b/src/main/java/com/chous/bookshelf/repository/ImageRepository.java
@@ -1,0 +1,15 @@
+package com.chous.bookshelf.repository;
+
+import com.chous.bookshelf.entity.Image;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface ImageRepository extends MongoRepository<Image, String> {
+
+    Optional<Image> findImageById(String id);
+
+//    Image findImageById(String id);
+//    List<Image> findAll();
+
+}

--- a/src/main/java/com/chous/bookshelf/service/ImageService.java
+++ b/src/main/java/com/chous/bookshelf/service/ImageService.java
@@ -1,0 +1,54 @@
+package com.chous.bookshelf.service;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.gridfs.GridFSBucket;
+import com.mongodb.client.gridfs.GridFSBuckets;
+import com.mongodb.client.gridfs.model.GridFSFile;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.gridfs.GridFsOperations;
+import org.springframework.data.mongodb.gridfs.GridFsResource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Service
+public class ImageService {
+
+    private final MongoDatabaseFactory dbFactory;
+    private final GridFsOperations gridFsOperations;
+
+    public ImageService(GridFsOperations gridFsOperations, MongoDatabaseFactory dbFactory) {
+        this.gridFsOperations = gridFsOperations;
+        this.dbFactory = dbFactory;
+    }
+
+    public String uploadImage(MultipartFile file, Long bookId) throws IOException {
+        DBObject metaData = new BasicDBObject();
+        metaData.put("book_id", bookId);
+
+        InputStream inputStream = file.getInputStream();
+        String fileName = file.getOriginalFilename();
+        String contentType = file.getContentType();
+
+        return gridFsOperations.store(inputStream, fileName, contentType, metaData).toString();
+    }
+
+    public GridFsResource getImageByBookId(Long bookId) {
+
+        Query query = Query.query(Criteria.where("metadata.book_id").is(bookId));
+        GridFSFile gridFSFile = gridFsOperations.findOne(query);
+
+        return (gridFSFile != null) ? new GridFsResource(gridFSFile, getGridFs().openDownloadStream(gridFSFile.getObjectId())) : null;
+    }
+
+    private GridFSBucket getGridFs() {
+        MongoDatabase db = dbFactory.getMongoDatabase();
+        return GridFSBuckets.create(db);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,19 @@ spring:
     url: jdbc:postgresql://localhost:5432/bookshelf
     username: chous
     password: chous
+  data:
+    mongodb:
+      authentication-database: admin
+      username: chous
+      password: chous
+      database: bookshelf
+      port: 27017
+      host: localhost
+      auto-index-creation: true
+  servlet:
+    multipart:
+      max-file-size: 1GB
+      max-request-size: 1GB
   jpa:
     open-in-view: false
     hibernate:


### PR DESCRIPTION
1. Добавить в сущность книги её изображение.
2. Реализовать эндпоинты для upload (multipart form-data) и download изображения по id книги.
3. Изображения сохранять в GridFS. В таблице книг хранить только id файла в GridFS.
4. Предусмотреть возможность аплоада и скачивания больших файлов (до 1 гб) на малых ресурсах JVM (параметр запуска "-Xmx512m").
5. Скачивание файлов должно быть реализовано через Content-Disposition хедер и поддерживать имена файлов на русском.